### PR TITLE
Sync gh-pages with master

### DIFF
--- a/_includes/slide.html
+++ b/_includes/slide.html
@@ -1,5 +1,5 @@
 <div class="step slide" {% for attr in post.data %} data-{{attr[0]}}="{{attr[1]}}"{% endfor %}>
   {{ post.title }}
-  
+
   {{ post.content }}
 </div>


### PR DESCRIPTION
As I mentioned in #4, GitHub will run Jekyll for us until we do something that
takes us outside the realm of normal Jekyll, so why not sync up master and
gh-pages now that master has the gh-pages-source branch in it?

(See also http://smerrill.github.com/hekyll/ - hooray!)
