### PR TITLE
Simple Slideshow

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Hekyll should:
 - Allow easier collaboration on these presentations through GitHub.
 - Allow users to commit and publish their presentations through GitHub using GitHub Pages.
 - Provide a good print stylesheet so that a user can print to PDF when conferences ask for slide decks.
+- Provide a simple slideshow mode for generating quick, regular slide shows (simple cross-fades between slides without the need to individually position each slide "Prezi-style."
 
 ## How to Use Hekyll
 

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,9 @@ pygments: true
 permalink: "/:title"
 
 ## Hekyll Configuration ##
-overview: true # true/false -- enabling this will add an overview slide at the end of the presentation
+simple-slideshow: false  # true/false -- when enabled, slide positioning is ignored and a simple cross-fade will be used to transition between slides.
+
+overview: true # true/false -- enabling this will add an overview slide at the end of the presentation. The overview slide will not display if simple-slideshow, above, is enabled.
 overview-data:
   x: 1000  # integer -- set this to the center x point of the overview slide, usually the center of your slide canvas area
   y: 1000  # integer -- set this to the center y point of the overview slide, usually the center of your slide canvas area

--- a/_includes/slide.html
+++ b/_includes/slide.html
@@ -1,4 +1,4 @@
-<div class="step{%if post.classes | size %}{% for class in post.classes %} {{class}}{% endfor %}{% else %} slide{% endif %}" {% for attr in post.data %} data-{{attr[0]}}="{{attr[1]}}"{% endfor %}>
+<div class="step{%if post.classes | size %}{% for class in post.classes %} {{class}}{% endfor %}{% else %} slide{% endif %}" {% unless site.simple-slideshow %}{% for attr in post.data %} data-{{attr[0]}}="{{attr[1]}}"{% endfor %}{% endunless %}>
   {% if post.title != "" %}<h1>{{ post.title }}</h1>{% endif %}
 
   {{ post.content }}

--- a/_layouts/presentation.html
+++ b/_layouts/presentation.html
@@ -3,7 +3,7 @@
 <head>
   {% include head.html %}
 </head>
-<body>
+<body{% if site.simple-slideshow %} class="simple-slideshow"{% endif; %}>
   <div id="impress" class="impress-not-supported">
     {{ content }}
   </div>

--- a/_sass/hekyll.scss
+++ b/_sass/hekyll.scss
@@ -62,6 +62,12 @@ h1 {
     opacity: 0.3;
 }
 
+/* Simple Slideshow Styles */
+
+.simple-slideshow .step:not(.active) {
+  opacity: 0;
+}
+
 /* overview step */
 
 #overview {

--- a/css/hekyll.css
+++ b/css/hekyll.css
@@ -130,6 +130,10 @@ h1 {
 .step:not(.active) {
   opacity: 0.3; }
 
+/* Simple Slideshow Styles */
+.simple-slideshow .step:not(.active) {
+  opacity: 0; }
+
 /* overview step */
 #overview {
   z-index: -1;

--- a/preso.html
+++ b/preso.html
@@ -6,6 +6,8 @@ title: Hekyll Presentation Generator
 {% for post in site.posts reversed %}
   {% include slide.html %}
 {% endfor %}
+{% unless site.simple-slideshow %}
 {% if site.overview %}
 <div id="overview" class="step" {% for attr in site.overview-data %} data-{{attr[0]}}="{{attr[1]}}"{% endfor %}></div>
 {% endif %}
+{% endunless %}


### PR DESCRIPTION
I thought it could be useful to add a simple slideshow mode for people who don't want to spend time laying out the position
of each slide and just really want to write a presentation in Markdown, so here is a way.

The config variable 'simple-slideshow' will cause each slide to be positioned in the same place and will simply cross-fade as a transition.
